### PR TITLE
separating racp data object from the racp characteristic

### DIFF
--- a/jdrfandroidbleparser/src/main/java/org/ehealthinnovation/jdrfandroidbleparser/bgm/characteristic/dataobjects/RACPDataObject.kt
+++ b/jdrfandroidbleparser/src/main/java/org/ehealthinnovation/jdrfandroidbleparser/bgm/characteristic/dataobjects/RACPDataObject.kt
@@ -1,0 +1,56 @@
+package org.ehealthinnovation.jdrfandroidbleparser.bgm.characteristic.dataobjects
+
+import org.ehealthinnovation.jdrfandroidbleparser.encodedvalue.bgm.racp.Filter
+import org.ehealthinnovation.jdrfandroidbleparser.encodedvalue.bgm.racp.Opcode
+import org.ehealthinnovation.jdrfandroidbleparser.encodedvalue.bgm.racp.Operator
+import org.ehealthinnovation.jdrfandroidbleparser.encodedvalue.bgm.racp.ResponseCode
+import org.ehealthinnovation.jdrfandroidbleparser.utility.BluetoothDateTime
+
+/**
+ * A data object to hold the result of parsing from [RACP].
+ * It also configures a command to be translated into [ByteArray] through [RACP]
+ */
+class RACPDataObject {
+    /**
+     * Op Code specifying the operation
+     */
+    var opcode: Opcode? = null
+
+
+    /**
+     * [operator] is a modifier to the operand. For example, [Operator.LAST_RECORD],
+     * [Operator.LESS_THAN_OR_EQUAL_TO]
+     */
+    var operator: Operator? = null
+
+    /** Since the value of the Operand is defined per service, when the RACP is used with the
+     *  Glucose Service, a Filter Type field is defined to enable the flexibility to filter based
+     *  on different criteria (i.e., Sequence Number or optionally User Facing Time).
+     */
+    var filterType: Filter? = null
+
+    /**
+     * The following variables stores the possible fields which constitute operands.
+     */
+    var minimumFilterValueSequenceNumber: Int? = null
+    var maximumFilterValueSequenceNumber: Int? = null
+    var minimumFilterValueUserFacingTime: BluetoothDateTime? = null
+    var maximumFilterValueUserFacingTime: BluetoothDateTime? = null
+
+    /**
+     * When the Report Number of Stored Records Op Code is written to the Record Access Control
+     * Point, the Server shall calculate and respond with a record count in UINT16 format based on
+     * filter criteria, Operator and Operand values.
+     */
+    var numberOfRecordResponse: Int? = null
+    var requestOpcode: Opcode? = null
+    var responseCode: ResponseCode? = null
+
+
+    /**
+     * Indicate whether the packet requires CRC
+     */
+    var hasCrc: Boolean = false
+
+}
+

--- a/jdrfandroidbleparser/src/main/java/org/ehealthinnovation/jdrfandroidbleparser/common/BaseCharacteristic.kt
+++ b/jdrfandroidbleparser/src/main/java/org/ehealthinnovation/jdrfandroidbleparser/common/BaseCharacteristic.kt
@@ -38,9 +38,11 @@ abstract class BaseCharacteristic(val uuid: Int) {
                 this.composingcharacteristic = it }
             if(characteristic == null){
                 this.composingcharacteristic = BluetoothGattCharacteristic(UUID.randomUUID(), BluetoothGattCharacteristic.PROPERTY_WRITE, BluetoothGattCharacteristic.PERMISSION_WRITE)
+
             }
         }
     }
+
 
     open val tag = BaseCharacteristic::class.java.canonicalName as String
     val nullValueException = "Null characteristic interpretation, aborting parsing."

--- a/jdrfandroidbleparser/src/main/java/org/ehealthinnovation/jdrfandroidbleparser/common/Composable.kt
+++ b/jdrfandroidbleparser/src/main/java/org/ehealthinnovation/jdrfandroidbleparser/common/Composable.kt
@@ -13,6 +13,6 @@ interface Composable {
      * Compose a given characteristic into the resulting [ByteArray].
      */
     @Throws(IllegalStateException::class)
-    fun composeCharacteristic(hasCrc : Boolean): ByteArray
+    fun composeCharacteristic(): ByteArray
 
 }

--- a/jdrfandroidbleparser/src/test/java/org/ehealthinnovation/jdrfandroidbleparser/bgm/characteristic/compoundcharacteristic/RACPTest.kt
+++ b/jdrfandroidbleparser/src/test/java/org/ehealthinnovation/jdrfandroidbleparser/bgm/characteristic/compoundcharacteristic/RACPTest.kt
@@ -1,6 +1,7 @@
 package org.ehealthinnovation.jdrfandroidbleparser.bgm.characteristic.compoundcharacteristic
 
 import org.ehealthinnovation.jdrfandroidbleparser.BaseTest
+import org.ehealthinnovation.jdrfandroidbleparser.bgm.characteristic.dataobjects.RACPDataObject
 import org.ehealthinnovation.jdrfandroidbleparser.encodedvalue.bgm.racp.Filter
 import org.ehealthinnovation.jdrfandroidbleparser.encodedvalue.bgm.racp.Opcode
 import org.ehealthinnovation.jdrfandroidbleparser.encodedvalue.bgm.racp.Operator
@@ -603,7 +604,7 @@ class RACPTest : BaseTest() {
         System.out.printf("testParsingOpcode\n")
         for (testVector in racpTestVectors) {
             System.out.printf("testing racpTestVector ${testVector.key}\n")
-            Assert.assertEquals(testVector.value.expectedOpcode, RACP(mockBTCharacteristic(testVector.value.testPacket), testVector.value.hasCrc).opcode)
+            Assert.assertEquals(testVector.value.expectedOpcode, RACP(mockBTCharacteristic(testVector.value.testPacket), testVector.value.hasCrc).racpData.opcode)
         }
     }
 
@@ -612,7 +613,7 @@ class RACPTest : BaseTest() {
         System.out.printf("testParsingOperator\n")
         for (testVector in racpTestVectors) {
             System.out.printf("testing racpTestVector ${testVector.key}\n")
-            Assert.assertEquals(testVector.value.expectedOperator, RACP(mockBTCharacteristic(testVector.value.testPacket), testVector.value.hasCrc).operator)
+            Assert.assertEquals(testVector.value.expectedOperator, RACP(mockBTCharacteristic(testVector.value.testPacket), testVector.value.hasCrc).racpData.operator)
         }
     }
 
@@ -621,7 +622,7 @@ class RACPTest : BaseTest() {
         System.out.printf("testParsingFilter\n")
         for (testVector in racpTestVectors) {
             System.out.printf("testing racpTestVector ${testVector.key}\n")
-            Assert.assertEquals(testVector.value.expectedFilter, RACP(mockBTCharacteristic(testVector.value.testPacket), testVector.value.hasCrc).filterType)
+            Assert.assertEquals(testVector.value.expectedFilter, RACP(mockBTCharacteristic(testVector.value.testPacket), testVector.value.hasCrc).racpData.filterType)
         }
     }
 
@@ -630,7 +631,7 @@ class RACPTest : BaseTest() {
         System.out.printf("testMinimumSequenceNumber\n")
         for (testVector in racpTestVectors) {
             System.out.printf("testing racpTestVector ${testVector.key}\n")
-            Assert.assertEquals(testVector.value.expectedMinimumSequenceNumber, RACP(mockBTCharacteristic(testVector.value.testPacket), testVector.value.hasCrc).minimumFilterValueSequenceNumber)
+            Assert.assertEquals(testVector.value.expectedMinimumSequenceNumber, RACP(mockBTCharacteristic(testVector.value.testPacket), testVector.value.hasCrc).racpData.minimumFilterValueSequenceNumber)
         }
     }
 
@@ -639,7 +640,7 @@ class RACPTest : BaseTest() {
         System.out.printf("testMaximumSequenceNumber\n")
         for (testVector in racpTestVectors) {
             System.out.printf("testing racpTestVector ${testVector.key}\n")
-            Assert.assertEquals(testVector.value.expectedMaximumSequenceNumber, RACP(mockBTCharacteristic(testVector.value.testPacket), testVector.value.hasCrc).maximumFilterValueSequenceNumber)
+            Assert.assertEquals(testVector.value.expectedMaximumSequenceNumber, RACP(mockBTCharacteristic(testVector.value.testPacket), testVector.value.hasCrc).racpData.maximumFilterValueSequenceNumber)
         }
     }
 
@@ -648,7 +649,7 @@ class RACPTest : BaseTest() {
         System.out.printf("testMinimumUserFacingTime\n")
         for (testVector in racpTestVectors) {
             System.out.printf("testing racpTestVector ${testVector.key}\n")
-            Assert.assertEquals(testVector.value.expectedMinimumUserFacingTime, RACP(mockBTCharacteristic(testVector.value.testPacket), testVector.value.hasCrc).minimumFilterValueUserFacingTime)
+            Assert.assertEquals(testVector.value.expectedMinimumUserFacingTime, RACP(mockBTCharacteristic(testVector.value.testPacket), testVector.value.hasCrc).racpData.minimumFilterValueUserFacingTime)
         }
     }
 
@@ -657,7 +658,7 @@ class RACPTest : BaseTest() {
         System.out.printf("testMaximumUserFacingTime\n")
         for (testVector in racpTestVectors) {
             System.out.printf("testing racpTestVector ${testVector.key}\n")
-            Assert.assertEquals(testVector.value.expectedMaximumUserFacingTime, RACP(mockBTCharacteristic(testVector.value.testPacket), testVector.value.hasCrc).maximumFilterValueUserFacingTime)
+            Assert.assertEquals(testVector.value.expectedMaximumUserFacingTime, RACP(mockBTCharacteristic(testVector.value.testPacket), testVector.value.hasCrc).racpData.maximumFilterValueUserFacingTime)
         }
     }
 
@@ -666,7 +667,7 @@ class RACPTest : BaseTest() {
         System.out.printf("testRequestedOpcode\n")
         for (testVector in racpTestVectors) {
             System.out.printf("testing racpTestVector ${testVector.key}\n")
-            Assert.assertEquals(testVector.value.expectedRequestOpcode, RACP(mockBTCharacteristic(testVector.value.testPacket), testVector.value.hasCrc).requestOpcode)
+            Assert.assertEquals(testVector.value.expectedRequestOpcode, RACP(mockBTCharacteristic(testVector.value.testPacket), testVector.value.hasCrc).racpData.requestOpcode)
         }
     }
 
@@ -675,7 +676,7 @@ class RACPTest : BaseTest() {
         System.out.printf("testRequestedResponse\n")
         for (testVector in racpTestVectors) {
             System.out.printf("testing racpTestVector ${testVector.key}\n")
-            Assert.assertEquals(testVector.value.expectedResponseCode, RACP(mockBTCharacteristic(testVector.value.testPacket), testVector.value.hasCrc).responseCode)
+            Assert.assertEquals(testVector.value.expectedResponseCode, RACP(mockBTCharacteristic(testVector.value.testPacket), testVector.value.hasCrc).racpData.responseCode)
         }
     }
 
@@ -684,7 +685,7 @@ class RACPTest : BaseTest() {
         System.out.printf("testNumberOfRecordResponse\n")
         for (testVector in racpTestVectors) {
             System.out.printf("testing racpTestVector ${testVector.key}\n")
-            Assert.assertEquals(testVector.value.expectedNumberOfRecord, RACP(mockBTCharacteristic(testVector.value.testPacket), testVector.value.hasCrc).numberOfRecordResponse)
+            Assert.assertEquals(testVector.value.expectedNumberOfRecord, RACP(mockBTCharacteristic(testVector.value.testPacket), testVector.value.hasCrc).racpData.numberOfRecordResponse)
         }
     }
 
@@ -694,6 +695,7 @@ class RACPTest : BaseTest() {
         var testRacp: RACP
         var successCount = 0
         var skipCount = 0
+        var racpData: RACPDataObject
 
         for (testVector in racpTestVectors) {
             System.out.printf("testing racpTestVector ${testVector.key}\n")
@@ -703,18 +705,20 @@ class RACPTest : BaseTest() {
                 continue
             }
             testRacp = RACP(mockBTCharacteristic(ByteArray(0)), testVector.value.hasCrc, isComposing = true)
-            testRacp.operator = testVector.value.expectedOperator
-            testRacp.opcode = testVector.value.expectedOpcode
-            testRacp.filterType = testVector.value.expectedFilter
-            testRacp.minimumFilterValueUserFacingTime = testVector.value.expectedMinimumUserFacingTime
-            testRacp.minimumFilterValueSequenceNumber = testVector.value.expectedMinimumSequenceNumber
-            testRacp.maximumFilterValueUserFacingTime = testVector.value.expectedMaximumUserFacingTime
-            testRacp.maximumFilterValueSequenceNumber = testVector.value.expectedMaximumSequenceNumber
-            testRacp.requestOpcode = testVector.value.expectedRequestOpcode
-            testRacp.responseCode = testVector.value.expectedResponseCode
-            testRacp.hasCrc = testVector.value.hasCrc
-            testRacp.numberOfRecordResponse = testVector.value.expectedNumberOfRecord
-            val composedPacket = testRacp.composeCharacteristic(testVector.value.hasCrc)
+            racpData = RACPDataObject()
+            racpData.operator = testVector.value.expectedOperator
+            racpData.opcode = testVector.value.expectedOpcode
+            racpData.filterType = testVector.value.expectedFilter
+            racpData.minimumFilterValueUserFacingTime = testVector.value.expectedMinimumUserFacingTime
+            racpData.minimumFilterValueSequenceNumber = testVector.value.expectedMinimumSequenceNumber
+            racpData.maximumFilterValueUserFacingTime = testVector.value.expectedMaximumUserFacingTime
+            racpData.maximumFilterValueSequenceNumber = testVector.value.expectedMaximumSequenceNumber
+            racpData.requestOpcode = testVector.value.expectedRequestOpcode
+            racpData.responseCode = testVector.value.expectedResponseCode
+            racpData.hasCrc = testVector.value.hasCrc
+            racpData.numberOfRecordResponse = testVector.value.expectedNumberOfRecord
+            testRacp.racpData = racpData
+            val composedPacket = testRacp.composeCharacteristic()
             System.out.printf("composed: " + composedPacket.contentToString() + "\n")
             System.out.printf("test packet: " + testVector.value.testPacket.contentToString() + "\n")
             Assert.assertTrue(testVector.value.testPacket.contentEquals(composedPacket))
@@ -727,6 +731,7 @@ class RACPTest : BaseTest() {
         System.out.printf("testAppendingCrC in RACP\n")
         var testRacp: RACP
         var skipCount = 0
+        var racpData: RACPDataObject
 
         for (testVector in racpTestVectors) {
             System.out.printf("testing racpTestVector ${testVector.key}\n")
@@ -736,18 +741,21 @@ class RACPTest : BaseTest() {
                 continue
             }
             testRacp = RACP(mockBTCharacteristic(ByteArray(0)), testVector.value.hasCrc, isComposing = true)
-            testRacp.operator = testVector.value.expectedOperator
-            testRacp.opcode = testVector.value.expectedOpcode
-            testRacp.filterType = testVector.value.expectedFilter
-            testRacp.minimumFilterValueUserFacingTime = testVector.value.expectedMinimumUserFacingTime
-            testRacp.minimumFilterValueSequenceNumber = testVector.value.expectedMinimumSequenceNumber
-            testRacp.maximumFilterValueUserFacingTime = testVector.value.expectedMaximumUserFacingTime
-            testRacp.maximumFilterValueSequenceNumber = testVector.value.expectedMaximumSequenceNumber
-            testRacp.requestOpcode = testVector.value.expectedRequestOpcode
-            testRacp.responseCode = testVector.value.expectedResponseCode
-            testRacp.hasCrc = testVector.value.hasCrc
-            testRacp.numberOfRecordResponse = testVector.value.expectedNumberOfRecord
-            val composedPacket = testRacp.composeCharacteristic(testVector.value.hasCrc)
+            racpData = RACPDataObject()
+
+            racpData.operator = testVector.value.expectedOperator
+            racpData.opcode = testVector.value.expectedOpcode
+            racpData.filterType = testVector.value.expectedFilter
+            racpData.minimumFilterValueUserFacingTime = testVector.value.expectedMinimumUserFacingTime
+            racpData.minimumFilterValueSequenceNumber = testVector.value.expectedMinimumSequenceNumber
+            racpData.maximumFilterValueUserFacingTime = testVector.value.expectedMaximumUserFacingTime
+            racpData.maximumFilterValueSequenceNumber = testVector.value.expectedMaximumSequenceNumber
+            racpData.requestOpcode = testVector.value.expectedRequestOpcode
+            racpData.responseCode = testVector.value.expectedResponseCode
+            racpData.hasCrc = testVector.value.hasCrc
+            racpData.numberOfRecordResponse = testVector.value.expectedNumberOfRecord
+            testRacp.racpData = racpData
+            val composedPacket = testRacp.composeCharacteristic()
             System.out.printf("composed: " + composedPacket.contentToString() + "\n")
             System.out.printf("test packet: " + testVector.value.testPacket.contentToString() + "\n")
             Assert.assertTrue(testVector.value.testPacket.contentEquals(composedPacket))


### PR DESCRIPTION
This PR is to pull out the data fields into a stand alone object, which can be passed to other layers for interpretation. It is the first step of breaking down a giant characteristic object.